### PR TITLE
Context export

### DIFF
--- a/src/clj_rpc/server.clj
+++ b/src/clj_rpc/server.clj
@@ -27,6 +27,19 @@
 
 (def rpc-default-port 9876)
 
+;;use dynamic method to export commands
+(defonce commands (atom {}))
+
+(defn export-func [the-var]
+  (let [[name cmd] (command/func->web-cmd the-var)]
+    (swap! commands assoc name cmd)))
+
+(defn export-ns
+  ([ns]
+     (export-ns (constantly true)))
+  ([pred ns]
+     (swap! commands merge (into {} (command/ns-web-cmds pred ns)))))
+
 (defn execute-method
   "get the function from the command-map according the method-name and
    execute this function with args

--- a/test/clj_rpc/test/command.clj
+++ b/test/clj_rpc/test/command.clj
@@ -2,29 +2,10 @@
   (:use [clj-rpc.command :reload true]
         [clojure.test]))
 
-
-;"check the abstract of the command"
-(deftest test-command
-    (let [cmd (mk-command "mk-command" (var mk-command))]
-      (is (=  (.name cmd) "mk-command"))
-      (is (.doc cmd))
-      (is (.arglists cmd))))
-
 ;"check a var is a function"
 (deftest test-var-fn 
   (is  (not (var-fn? #'clojure.core/unquote)))
   (is  (var-fn? #'clojure.core/+)))
-
-;"check the get-commands"
-(deftest test-get-commands
-  (let [fs (get-commands 'clojure.core)
-        s-fs (get-commands 'clojure.core #'clojure.core/+ #'clojure.core/meta)
-        cmd (get fs "meta")]
-    (is (= (.name cmd) "meta") ) 
-    (is (nil? (get fs "unquote")))
-    (is (get s-fs "+"))
-    (is (get s-fs "meta"))
-    (is (not (get s-fs "-")))))
 
 (deftest test-web-func
   (let [web+ (web-func + [:session :number])]

--- a/test/clj_rpc/test/integrate.clj
+++ b/test/clj_rpc/test/integrate.clj
@@ -13,8 +13,8 @@
 (use-fixtures :once around-server)
 
 (deftest test-invoke
-  (server/export-func str "str")
-  (server/export-func concat "concat")
+  (server/export-func #'str)
+  (server/export-func #'concat)
   (doseq [endp (map #(client/rpc-endpoint :on-wire %) ["clj" "json"])]
     (is (= "中文测试"
            (client/invoke-rpc endp "str" "中文" "测试")))


### PR DESCRIPTION
Try to export modified (web enabled) function instead of raw function, which enabled us to encapsulate state into the function, e.g. let the function take parameters from web request.
